### PR TITLE
Added daily printouts of failure classifications.

### DIFF
--- a/analyse_data.py
+++ b/analyse_data.py
@@ -7,12 +7,13 @@ from datetime import datetime
 import json
 
 import dateutil
-
+import pandas
 
 from jenkins._common import BASE_DIR
 from jenkins._analysis import (
     analyze_failing_tests,
     get_classified_failures,
+    get_daily_classification_pivot,
     get_top_failing_jobs,
     group_by_classification,
     group_by_test_name,
@@ -79,6 +80,11 @@ def print_common_failure_reasons(build_data):
     print(group_by_classification(get_classified_failures(build_data)))
 
 
+def print_common_failure_daily(build_data):
+    print("Daily drill-down on failure classifications:")
+    print(get_daily_classification_pivot(get_classified_failures(build_data)))
+
+
 def print_commonly_failing_tests(build_data):
     print("Tests with the most failures")
     print(group_by_test_name(analyze_failing_tests(build_data)).head(20))
@@ -94,6 +100,10 @@ def main():
     )
     opts = parser.parse_args()
     builds = load_build_data(since=opts.since)
+
+    pandas.set_option('expand_frame_repr', False)
+    print("Showing data since: ", opts.since)
+    print("")
     print_summary_results(builds)
     print("")
     print("")
@@ -102,6 +112,9 @@ def main():
     print("")
     print("")
     print_common_failure_reasons(build_data)
+    print("")
+    print("")
+    print_common_failure_daily(build_data)
     print("")
     print("")
     print_commonly_failing_tests(build_data)

--- a/analyse_data.py
+++ b/analyse_data.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 
 from argparse import ArgumentParser
-from datetime import datetime
 import json
 
 import dateutil
@@ -12,6 +11,7 @@ import pandas
 from jenkins._common import BASE_DIR
 from jenkins._analysis import (
     analyze_failing_tests,
+    get_datetime,
     get_classified_failures,
     get_daily_classification_pivot,
     get_top_failing_jobs,
@@ -37,7 +37,7 @@ def builds_since(builds, since):
         records in `builds` that are newer than `since`.
     """
     return filter(
-        lambda b: datetime.fromtimestamp(float(b['timestamp'])/1000) > since,
+        lambda b: get_datetime(b['timestamp']) > since,
         builds)
 
 
@@ -75,14 +75,14 @@ def print_top_failing_jobs(build_data):
     print(failing_jobs.head(20))
 
 
-def print_common_failure_reasons(build_data):
+def print_common_failure_reasons(classified_failure_data):
     print("Classification of failures")
-    print(group_by_classification(get_classified_failures(build_data)))
+    print(group_by_classification(classified_failure_data))
 
 
-def print_common_failure_daily(build_data):
+def print_common_failure_daily(classified_failure_data):
     print("Daily drill-down on failure classifications:")
-    print(get_daily_classification_pivot(get_classified_failures(build_data)))
+    print(get_daily_classification_pivot(classified_failure_data))
 
 
 def print_commonly_failing_tests(build_data):
@@ -111,10 +111,11 @@ def main():
     print_top_failing_jobs(build_data)
     print("")
     print("")
-    print_common_failure_reasons(build_data)
+    classified_failure_data = get_classified_failures(build_data)
+    print_common_failure_reasons(classified_failure_data)
     print("")
     print("")
-    print_common_failure_daily(build_data)
+    print_common_failure_daily(classified_failure_data)
     print("")
     print("")
     print_commonly_failing_tests(build_data)

--- a/jenkins/_analysis.py
+++ b/jenkins/_analysis.py
@@ -60,7 +60,7 @@ def _flatten_build(build):
             'job': sub_build['jobName'],
             'result': sub_build['result'],
             'url': sub_build['url'],
-            'datetime': _get_datetime(build['timestamp'])
+            'datetime': get_datetime(build['timestamp'])
         }
 
 
@@ -175,6 +175,17 @@ def _classify_build_log(log, path):
     return "Unknown"
 
 
+def get_datetime(timestamp):
+    """
+    Return the datetime from a jenkins timestamp.
+
+    :param int timestamp: The timestamp to convert in ms since utc
+        to a datetime
+    :return datetime: The corresponding datetime.
+    """
+    return datetime.datetime.fromtimestamp(float(timestamp)/1000)
+
+
 def _get_week_number(timestamp):
     """
     Return a week number for the timestamp.
@@ -187,19 +198,8 @@ def _get_week_number(timestamp):
         to a week number.
     :return int: the week number.
     """
-    dt = datetime.datetime.fromtimestamp(float(timestamp)/1000)
+    dt = get_datetime(timestamp)
     return dt.year * 100 + dt.isocalendar()[1]
-
-
-def _get_datetime(timestamp):
-    """
-    Return the datetime from a jenkins timestamp.
-
-    :param int timestamp: The timestamp to convert in ms since utc
-        to a datetime
-    :return datetime: The corresponding datetime.
-    """
-    return datetime.datetime.fromtimestamp(float(timestamp)/1000)
 
 
 def _get_numeric_result(result_str):

--- a/jenkins/_analysis.py
+++ b/jenkins/_analysis.py
@@ -60,6 +60,7 @@ def _flatten_build(build):
             'job': sub_build['jobName'],
             'result': sub_build['result'],
             'url': sub_build['url'],
+            'datetime': _get_datetime(build['timestamp'])
         }
 
 
@@ -155,6 +156,15 @@ def _classify_build_log(log, path):
         return "[FLOC-?] docs failed to upload to s3"
     if 'git fetch --tags --progress https://github.com/ClusterHQ/flocker.git +refs/heads/*:refs/remotes/upstream/*\nERROR: timeout after 10 minutes' in log:
         return "[FLOC-?] failed to fetch from github"
+    if ("ReadTimeoutError: HTTPConnectionPool(host='devpi.clusterhq.com', "
+            "port=3141): Read timed out." in log):
+        return "[FLOC-?] devpi.clusterhq.com down"
+    if ("No matching distribution found for effect==0.1a13 "
+            "(from -r /tmp/requirements.txt (line 6))" in log):
+        return "[FLOC-?] Pip failure in docker build."
+    if ("Could not resolve host: github.com" in log or
+            "curl: (6) Could not resolve host: api.github.com" in log):
+        return "[FLOC-?] Network to github down."
 
     # XXX: overly hacky and broad. Not caught by either the junit processing
     # check due to FLOC-3817, or by the trial failure message check because it is showing
@@ -179,6 +189,17 @@ def _get_week_number(timestamp):
     """
     dt = datetime.datetime.fromtimestamp(float(timestamp)/1000)
     return dt.year * 100 + dt.isocalendar()[1]
+
+
+def _get_datetime(timestamp):
+    """
+    Return the datetime from a jenkins timestamp.
+
+    :param int timestamp: The timestamp to convert in ms since utc
+        to a datetime
+    :return datetime: The corresponding datetime.
+    """
+    return datetime.datetime.fromtimestamp(float(timestamp)/1000)
 
 
 def _get_numeric_result(result_str):
@@ -302,6 +323,27 @@ def group_by_classification(failures):
     """
     return failures.groupby('classification').size().sort_values(
         ascending=False)
+
+
+def get_daily_classification_pivot(failures):
+    """
+    Given a DataFrame of classified failures, group the frame by classification
+    and day to produce a table that shows the daily occurances of each of the
+    types of failures.
+
+    :param pandas.DataFrame failures: the DataFrame with classified failures.
+    :return pandas.DataFrame: A pandas.DataFrame pivot table with rows for each
+        type of failure and columns for each day of data. This can be scanned
+        to see if a failure has gone away, or has re-emerged in recent days.
+    """
+    return pandas.pivot_table(
+        failures,
+        index='classification',
+        columns=pandas.Grouper(key='datetime', freq='D', sort=True),
+        values='url',
+        aggfunc='count',
+        fill_value=0
+    )
 
 
 def group_by_test_name(failures):


### PR DESCRIPTION
This is useful for seeing what the trend is on each type of failure. It is easy
to tell at a glance if a particular classification of failure is going away, or
has recently emerged with these being rendered.

Additionally, added a few more classifications. Now I do not see any
unclassified failures when I run against data downloaded today.

The new daily drill-down looks like the following on the terminal:

```
Classification of failures
classification
[FLOC-3725] NullPointerException                                 178
Failed Test                                                       36
[FLOC-4172] java.io.IOException: remote file operation failed     30
[FLOC-?] Build timeout                                             9
[FLOC-?] Network to github down.                                   7
[FLOC-?] devpi.clusterhq.com down                                  4
[FLOC-?] apt download failure                                      2
[FLOC-?] Pip failure in docker build.                              2
dtype: int64


Daily drill-down on failure classifications:
datetime                                            2016-01-28  2016-01-29  2016-02-01  2016-02-02  2016-02-03  2016-02-04  2016-02-05  2016-02-08  2016-02-09  2016-02-10  2016-02-11  2016-02-15
classification                                                                                                                                                                                    
Failed Test                                                  4           7           4           6           2           2           3           3           2           2           0           1
[FLOC-3725] NullPointerException                             0           0           0           5          51          33          35          50           4           0           0           0
[FLOC-4172] java.io.IOException: remote file op...           0           6           0           0           0           7           4           3           0          10           0           0
[FLOC-?] Build timeout                                       2           0           1           1           0           2           0           0           0           1           2           0
[FLOC-?] Network to github down.                             0           1           2           2           2           0           0           0           0           0           0           0
[FLOC-?] Pip failure in docker build.                        0           0           0           0           2           0           0           0           0           0           0           0
[FLOC-?] apt download failure                                0           0           0           1           0           0           0           0           1           0           0           0
[FLOC-?] devpi.clusterhq.com down                            4           0           0           0           0           0           0           0           0           0           0           0


Tests with the most failures
test_case_name
flocker.node.agents.functional.test_cinder.CinderBlockDeviceAPIInterfaceTests.test_detach_volume                                16
flocker.node.agents.functional.test_cinder.CinderBlockDeviceAPIInterfaceTests.test_reattach_detached_volume                      7
...
```
