### PR TITLE
[FLOC-4191] Update data analysis to approximate time to merge.

### DIFF
--- a/analyse_data.py
+++ b/analyse_data.py
@@ -7,10 +7,12 @@ import json
 
 import dateutil
 import pandas
+import numpy
 
 from jenkins._common import BASE_DIR
 from jenkins._analysis import (
     analyze_failing_tests,
+    get_daily_time_to_merge,
     get_datetime,
     get_classified_failures,
     get_daily_classification_pivot,
@@ -90,6 +92,11 @@ def print_commonly_failing_tests(build_data):
     print(group_by_test_name(analyze_failing_tests(build_data)).head(20))
 
 
+def print_daily_time_to_merge(build_data):
+    print("Approximation of time-to-merge across days:")
+    print(get_daily_time_to_merge(build_data))
+
+
 def main():
     parser = ArgumentParser(
         'analyse_data.py', description="Analyze Jenkins build logs"
@@ -119,6 +126,9 @@ def main():
     print("")
     print("")
     print_commonly_failing_tests(build_data)
+    print("")
+    print("")
+    print_daily_time_to_merge(build_data)
 
 
 if __name__ == '__main__':

--- a/download_data.py
+++ b/download_data.py
@@ -67,8 +67,8 @@ def main(reactor):
         BASE_DIR.makedirs()
     base_path = 'job/ClusterHQ-flocker/job/master/job/__main_multijob/'
     d = jenkins_json_get(
-        base_path + 'api/json?tree=builds[result,number,timestamp,'
-        'subBuilds[result,buildNumber,jobName,url,timestamp]]')
+        base_path + 'api/json?tree=builds[result,number,timestamp,duration,'
+        'subBuilds[result,buildNumber,jobName,url,timestamp,duration]]')
 
     def write_main_data(data):
         filename = 'api.' + datetime.datetime.utcnow().isoformat() + '.json'


### PR DESCRIPTION
Wrote a simple approximation of how long from "This branch is ready for merge"
to "CI tests are done and green". Added a daily printout of the average value
per day to the analysis script.

New code renders like the following:

```
Approximation of time-to-merge across days:
datetime
2016-01-29    0 days 00:52:45.818250
2016-01-30    0 days 00:48:27.791000
2016-01-31                   No data
2016-02-01    0 days 01:03:59.795666
2016-02-02    0 days 01:00:37.812000
2016-02-03    0 days 01:02:55.422500
2016-02-04    0 days 01:05:52.436375
2016-02-05    0 days 01:01:24.646333
2016-02-06                   No data
2016-02-07                   No data
2016-02-08    0 days 01:07:21.200333
2016-02-09    0 days 01:36:24.578333
2016-02-10    0 days 01:44:49.497111
2016-02-11    0 days 01:42:56.941200
2016-02-12    0 days 01:32:09.793000
2016-02-13    0 days 01:29:19.414500
2016-02-14    0 days 01:58:28.525500
2016-02-15    0 days 02:29:30.224400
2016-02-16    0 days 01:28:45.942000
Freq: D, Name: duration_until_mergable, dtype: object
```
